### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Development
 
 I personally build the packages on the target platform, because Qubes OS templates make that easy, and it makes sense to me to do it. For now I'll assume you do the same.
 
-For Qubes OS R4.1, that means a **Fedora 32** _qube_. That _qube_ can be completely offline.
+For Qubes OS R4.1, that means a **Fedora 32** _qube_. That _qube_ can be completely offline, and it can be disposable.
 
 
 #### Tito and rpm-sign
@@ -239,6 +239,12 @@ In order to build packages for a given formula (e.g. the split-SSH formula):
    ```
 
   [stag]: https://www.qubes-os.org/doc/code-signing/#using-pgp-with-git
+
+### Publishing packages
+
+See 🌳 [qubes-packages][qubes-packages], a template repository of RPM packages for Qubes OS. That project contains instructions and code to create your own RPM repository and manage it on untrusted infrastructure.
+
+  [qubes-packages]: https://github.com/gonzalo-bulnes/qubes-packages
 
 References
 ----------

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ A collection of user Salt formulas for Qubes OS.
   [split-ssh-src]: ./packages/split-ssh/src
   [split-ssh-pkg]: ./packages/split-ssh
 
+Overview
+--------
+
+This repository contains a collection of Salt formulas that I use in Qubes OS, along with **the tooling necessary to create RPM packages** in order to get those Salt formulas into _dom0_ in a reasonably secure fashion.
+
+See [RPM packaging in the context of Qubes OS][rpm-packaging] for more information about why RPM packages may be a good way to copy files into _dom0_.
+
+See also the [References](#references) section in this README, bear in mind that your cirumstances and mine could be different, and use own judgement.
+
+  [rpm-packaging]: https://docs.gonzalobulnes.com/configuration_management.html#rpm-packaging
+
 Usage
 -----
 
@@ -247,7 +258,7 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 License
 -------
 
-Copyright © 2021 Gonzalo Bulnes Guilpain
+Copyright © 2021–2023 Gonzalo Bulnes Guilpain
 
 This project is released under the GNU General Public License v2 (see [LICENSE](LICENSE.md)).
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Usage
 Enable the Salt [user directories][qubes-user-dirs] if you haven't already. This allows to install Salt formulas without mixing them with the `base` formulas that are maintained by the Qubes OS team.
 
 ```sh
+# dom0
+
 sudo qubesctl top.enable qubes.user-dirs
 ```
 
@@ -31,56 +33,35 @@ sudo qubesctl top.enable qubes.user-dirs
 Then apply the state to ensure the directories are present:
 
 ```sh
+# dom0
+
 sudo qubesctl state.apply
 ```
 
-### Step-by-step
+### Installation
 
-This repository contains multiple formulas and it is not required to use them all. For each of them, the same enabling steps apply, and `split-ssh` will be used as an example.
+This repository contains multiple formulas and it is not required to use them all. For each of them, similar installation and usage instructions apply: please refer to their respective READMEs for details.
 
-#### Install the formula
+### Useful commands
 
-In order to be able to use a formula, the state definition should be present in the `/srv/user_salt/` directory of _dom0_, and the pillar definition in `/srv/user_pillar`.
-
-
-> ⚠ **Security warning**: Since any domain is _less trusted_ than _dom0_ (by definition), copying anything into _dom0_ requires extreme caution. See [References](#references) for details, and use own judgement.
->
-> Next to each state **sources** (e.g. [split-SSH sources][split-ssh-src]), this repository provides **packaging tools** (e.g. [split-SSH packaging][split-ssh-pkg]) that allow to take advantage of [dom0's secure update][secure-update] to install the sources. That's what I prefer, but please bear in mind that your circumstances and mine could be different.
-
-  [secure-update]: https://www.qubes-os.org/doc/dom0-secure-updates
-
-
-No matter how you decide to perform this step, the end result should be a directory containing one or more `.top` files (and the corresponding `.sls` and other files), as well as a directory containing a `config.yaml` file:
-
-```sh
-/srv/user_pillar/split-ssh # contains the configuration
-/srv/user_salt/split-ssh   # contains the .top files
-```
-#### Adjust the configuration to fit your needs
-
-The state will be defined by the configuration stored in the pillar. In our example, you can find the default configuration in `/srv/user_pillar/split-ssh/config.yaml` and modify it to fit your needs.
-
-#### Enable the state
+#### Enabling a formula
 
 In Qubes OS, Salt states are applied by `qubesctl`. No state will be applied by `qubesctl` unless its _top files_ have been enabled.
 
-In our example, three _top files_ are provided:
-
-```sh
-sudo ls /srv/user_salt/split-ssh/*.top
-# split-ssh/client.top  split-ssh/policy.top  split-ssh/vault.top
-```
-
 In `qubesctl`/Salt context, the directories are separated by a `.` and the `.top` extension is omitted.
-The _top files_ can be enabled all at once:
+Multiple _top files_ can be enabled all at once:
 
 ```sh
+# dom0
+
 sudo qubesctl top.enable split-ssh.client split-ssh.policy split-ssh.vault
 ```
 
-At any time, you can list all the enabled states:
+At any time, you can list all the enabled formulas:
 
 ```sh
+# dom0
+
 sudo qubesctl top.enabled
 # local
 #     ----------
@@ -93,25 +74,30 @@ sudo qubesctl top.enabled
 #         - /srv/salt/_tops/base/qubes.user-dirs.top
 ```
 
-#### Apply the state
+#### Applying the state
 
-All the enabled states can be applied at once:
+If you've got time to spare, the enabled states can be applied at once across all qubes:
 
 ```sh
+# dom0
+
 sudo qubesctl --all state.apply
 ```
 
 Each state targets one or more qubes, and if you know which qubes you're modifying you can save some time by targetting them specifically.
-For example, the `split-ssh` state targets `dom0` by default, as well as the `fedora-32` template, and two qubes called `ssh-vault` and `ssh-client`:
 
 ```sh
-sudo qubesctl --targets=fedora-32,ssh-client,ssh-vault state.apply
+# dom0
+
+sudo qubesctl --targets=debian-11,ssh-client,ssh-vault state.apply
 ```
 
 Note that _dom0_ is always implicitly targetted by `qubesctl` (and appears in the output as `local`). If you know it doesn't need to be updated, you can skip _dom0_:
 
 ```sh
-sudo qubesctl --skip-dom0 --targets=fedora-32,ssh-client,ssh-vault state.apply # in this example, that would be enough if the client and vault qubes already exist
+# dom0
+
+sudo qubesctl --skip-dom0 --targets=debian-11,ssh-client,ssh-vault state.apply
 ```
 
 Development
@@ -131,12 +117,16 @@ For Qubes OS R4.1, that means a **Fedora 32** _qube_. That _qube_ can be complet
 [Tito][tito] is in charge of building the RPM packages. Make sure it is installed:
 
 ```sh
+# fedora-32
+
 sudo dnf install tito
 ```
 
 The entire point of building our own packages is being able to sign them. To do that, `rpm-sign` must be installed.
 
 ```sh
+# fedora-32
+
 sudo dnf install rpm-sign
 ```
 
@@ -147,6 +137,8 @@ sudo dnf install rpm-sign
 If you use _Split-GPG_ on Qubes OS, some configuration is needed to ensure that RPM tooling can sign the packages. That can be done adding the following to the `~/.rpmmarcos` file of the _qube_ where you'll build the packages. (Of course, that qube also needs allow the use of Split GPG.)
 
 ```specfile
+# ~/.rpmmacros
+
 # ...
 
 # Use split-GPG. The options are adjusted below.


### PR DESCRIPTION
- Remove mostly redundant section "Usage" section from main README
- Organize the Salt examples as a cheatsheet of useful commands
- Complete the circle with a mention of package publishing
- Ensure all code blocks include appropriate context (where the command runs or which file it is)