### PR TITLE
Release qvm-features-in-pillar-1.0.0-2

### DIFF
--- a/.tito/packages/qubes-mgmt-salt-user-qvm-features-in-pillar
+++ b/.tito/packages/qubes-mgmt-salt-user-qvm-features-in-pillar
@@ -1,1 +1,1 @@
-1.0.0-1 packages/qvm-features-in-pillar/src/qvm-features-in-pillar-formula
+1.0.0-2 packages/qvm-features-in-pillar/src/qvm-features-in-pillar-formula

--- a/packages/qvm-features-in-pillar/Makefile
+++ b/packages/qvm-features-in-pillar/Makefile
@@ -8,7 +8,7 @@ CURRENT_VERSION ?= 1.0.0
 
 # The release number for the current version of the sources
 # Tito is meant to manage this, but I haven't quite figured out that yet.
-CURRENT_RELEASE ?= 1
+CURRENT_RELEASE ?= 2
 
 # The following parameters repeat the RPM spec configuration.
 # I like the convenience of automating these tasks, but haven't

--- a/packages/qvm-features-in-pillar/src/qvm-features-in-pillar-formula/qubes-mgmt-salt-user-qvm-features-in-pillar.spec
+++ b/packages/qvm-features-in-pillar/src/qvm-features-in-pillar-formula/qubes-mgmt-salt-user-qvm-features-in-pillar.spec
@@ -2,7 +2,7 @@
 
 Name:           qubes-mgmt-salt-user-qvm-features-in-pillar
 Version:        1.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A Salt formula that exposes QVM features in Salt pillar
 
 License:        GPLv2
@@ -30,5 +30,8 @@ make install DESTDIR=%{buildroot}
 /srv/user_salt/qvm-features-in-pillar
 
 %changelog
+* Thu Sep 28 2023 Gonzalo Bulnes Guilpain <gon.bulnes@fastmail.com>
+- Re-build with RPM configuration that works towards reproducible builds
+
 * Wed Sep 13 2023 Gonzalo Bulnes Guilpain <gon.bulnes@fastmail.com>
 - Initial packaging

--- a/packages/qvm-features-in-pillar/src/qvm-features-in-pillar-formula/qubes-mgmt-salt-user-qvm-features-in-pillar.spec.tmpl
+++ b/packages/qvm-features-in-pillar/src/qvm-features-in-pillar-formula/qubes-mgmt-salt-user-qvm-features-in-pillar.spec.tmpl
@@ -30,5 +30,8 @@ make install DESTDIR=%{buildroot}
 /srv/user_salt/qvm-features-in-pillar
 
 %changelog
+* Thu Sep 28 2023 Gonzalo Bulnes Guilpain <gon.bulnes@fastmail.com>
+- Re-build with RPM configuration that works towards reproducible builds
+
 * Wed Sep 13 2023 Gonzalo Bulnes Guilpain <gon.bulnes@fastmail.com>
 - Initial packaging


### PR DESCRIPTION
This is a follow up on #21 

I re-built the package using RPM options that work towards enabling _reproducible builds_. See #22.
The package is published in my :deciduous_tree: [personal repository](https://pkg.gonzalobulnes.org). 
